### PR TITLE
default to 1 for hops

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -39,6 +39,7 @@ services:
       - NO_BUNDLE=true
       # transaction timeout to not get stuck on a pending tx
       - TIMEOUT=600
+      - HOPS=${BINARY_SEARCH_HOPS:-1}
     profiles: ["flare", "flare-bot"]
 
 volumes:


### PR DESCRIPTION
## Motivation

defaulting the hops to a high number causes huge spam on the RPC for something that is an edge case

## Solution

default hops to 1 with ability to override in env

## Checks

By submitting this for review, I'm confirming I've done the following:
- [x] made this PR as small as possible
- [ ] unit-tested any new functionality
- [ ] linked any relevant issues or PRs
